### PR TITLE
fix: agents-AI link, remove dead demo cards

### DIFF
--- a/components/Misc/AgentTerminal.component.tsx
+++ b/components/Misc/AgentTerminal.component.tsx
@@ -89,9 +89,9 @@ const TREE = `~/renan.agent/
 ├── experience.log
 ├── contact.txt
 ├── projects/
-│   ├── agents-cookbook/
-│   ├── semantic-search-arxiv/
-│   └── flight-delays/
+│   ├── agents-AI/
+│   ├── rag-chatbot/
+│   └── mcp-tools-server/
 └── experience/
     ├── 2025-tamy-ai/      (current)
     ├── 2023-weg/          (1y 10m)
@@ -352,9 +352,9 @@ export const AgentTerminal = ({
 
     if (cmd === "projects" || cmd === "proj") {
       const projs: [string, string][] = [
-        ["  → agents-cookbook · LangChain/LangGraph + MCP + RAG", "https://github.com/RenanMiqueloti/agents-cookbook"],
-        ["  → semantic-search-arxiv · hybrid retrieval (BM25 + dense + RRF)", "https://huggingface.co/spaces/RenanMiqueloti/semantic-search-arxiv"],
-        ["  → flight-delays · scikit-learn + SHAP + Streamlit", "https://renan-flight-delays.streamlit.app"],
+        ["  → agents-AI · LangGraph + MCP + HITL + evals", "https://github.com/RenanMiqueloti/agents-AI"],
+        ["  → rag-chatbot · Qdrant + hybrid retrieval + cross-encoder rerank", "https://github.com/RenanMiqueloti/rag-chatbot"],
+        ["  → mcp-tools-server · custom MCP server", "https://github.com/RenanMiqueloti/mcp-tools-server"],
         ["  → todos os repos públicos", PERSONA.github],
       ];
       return [

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -268,24 +268,6 @@ export const MESSAGES: Record<Locale, Messages> = {
           url: "https://github.com/RenanMiqueloti/rag-chatbot",
           cta: "Ver no GitHub",
         },
-        {
-          label: "INDISPONÍVEL",
-          title: "semantic-search-arxiv",
-          description:
-            "Sistema de busca híbrida (dense + BM25 + RRF) sobre 74 papers seminais de IA. Métricas: R@5=97%, MRR=0.88, ~12ms/query · IC 95% bootstrap · n=30 queries (PT-BR + EN). Execução local em Hugging Face Space.",
-          tags: ["e5-multilingual", "BM25 + RRF", "Gradio"],
-          url: "https://huggingface.co/spaces/RenanMiqueloti/semantic-search-arxiv",
-          cta: "Abrir demo",
-        },
-        {
-          label: "INDISPONÍVEL",
-          title: "flight-delays",
-          description:
-            "Modelo de classificação para predição de atraso de voos, com explicações locais via SHAP. Servido em interface web com Streamlit.",
-          tags: ["scikit-learn", "SHAP", "Streamlit"],
-          url: "https://renan-flight-delays.streamlit.app",
-          cta: "Abrir demo",
-        },
       ],
       seeAllCta: "$ ver todos os repos no GitHub",
       seeAllUrl: SHARED_FEATURED_URL,
@@ -489,24 +471,6 @@ export const MESSAGES: Record<Locale, Messages> = {
           tags: ["LangGraph", "Qdrant", "Hybrid + Rerank", "FastAPI"],
           url: "https://github.com/RenanMiqueloti/rag-chatbot",
           cta: "View on GitHub",
-        },
-        {
-          label: "UNAVAILABLE",
-          title: "semantic-search-arxiv",
-          description:
-            "Hybrid search system (dense + BM25 + RRF) over 74 seminal AI papers. Metrics: R@5=97%, MRR=0.88, ~12ms/query · 95% bootstrap CI · n=30 queries (PT-BR + EN). Runs locally on Hugging Face Space.",
-          tags: ["e5-multilingual", "BM25 + RRF", "Gradio"],
-          url: "https://huggingface.co/spaces/RenanMiqueloti/semantic-search-arxiv",
-          cta: "Open demo",
-        },
-        {
-          label: "UNAVAILABLE",
-          title: "flight-delays",
-          description:
-            "Classification model for flight delay prediction with local SHAP explanations. Served through a Streamlit web interface.",
-          tags: ["scikit-learn", "SHAP", "Streamlit"],
-          url: "https://renan-flight-delays.streamlit.app",
-          cta: "Open demo",
         },
       ],
       seeAllCta: "$ see all repos on GitHub",


### PR DESCRIPTION
- AgentTerminal: `agents-cookbook` (link 404) → `agents-AI` no TREE ASCII e no comando `projects`. Lista atualizada para os featured atuais: `agents-AI`, `rag-chatbot`, `mcp-tools-server`.
- i18n: tira os dois cards `INDISPONÍVEL`/`UNAVAILABLE` (`semantic-search-arxiv`, `flight-delays`) — demos não hospedadas mais. Mantém `unavailableLabel` no schema pra reusar depois sem mudança de tipo.
- `public/robots.txt` e `sitemap.xml` já estavam completos (changefreq + hreflangs `/en`).

Local: `npm run build` clean, 9 páginas estáticas.