### PR TITLE
feat(projects): add industrial-anomaly-detection and mcp-tools-server; remove WIP from agents-AI

### DIFF
--- a/components/Sections/Projects.section.tsx
+++ b/components/Sections/Projects.section.tsx
@@ -29,10 +29,6 @@ const Projects = () => {
                 rel="noopener noreferrer"
                 className="group relative block h-full p-8 md:p-10 overflow-hidden hover:bg-zinc-900/30 transition-colors"
               >
-                <div className="absolute top-4 right-4 z-10 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border border-amber-500/40 bg-amber-500/10 font-mono text-[10px] uppercase tracking-[0.2em] text-amber-300">
-                  <span className="w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" />
-                  {p.comingSoonLabel}
-                </div>
                 <div className="relative">
                   <span className="font-mono text-[11px] uppercase tracking-[0.2em] text-emerald-300/90">
                     {featured.label}

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -268,6 +268,24 @@ export const MESSAGES: Record<Locale, Messages> = {
           url: "https://github.com/RenanMiqueloti/rag-chatbot",
           cta: "Ver no GitHub",
         },
+        {
+          label: "DESTAQUE",
+          title: "industrial-anomaly-detection",
+          description:
+            "Detecção de anomalias não supervisionada em séries temporais industriais: Isolation Forest, OC-SVM, AutoEncoder (PyTorch) e SHAP para explicabilidade. Bootstrap CI e dashboard Streamlit para visualização.",
+          tags: ["Python", "PyTorch", "SHAP", "Streamlit", "Anomaly Detection"],
+          url: "https://github.com/RenanMiqueloti/industrial-anomaly-detection",
+          cta: "Ver no GitHub",
+        },
+        {
+          label: "DESTAQUE",
+          title: "mcp-tools-server",
+          description:
+            "MCP server customizado com 6 ferramentas utilitárias expostas via stdio: datetime, calculate, text_stats, json_extract, search_knowledge e http_get. Compatível com Claude Desktop e qualquer cliente MCP.",
+          tags: ["Python", "MCP", "Claude", "LangGraph"],
+          url: "https://github.com/RenanMiqueloti/mcp-tools-server",
+          cta: "Ver no GitHub",
+        },
       ],
       seeAllCta: "$ ver todos os repos no GitHub",
       seeAllUrl: SHARED_FEATURED_URL,
@@ -470,6 +488,24 @@ export const MESSAGES: Record<Locale, Messages> = {
             "Production RAG pipeline with LangGraph orchestrating retrieve → rerank → generate. Hybrid retrieval BM25 + semantic with RRF, cross-encoder re-ranking, FastAPI streaming and an LLM-as-judge eval harness (relevance, faithfulness, completeness).",
           tags: ["LangGraph", "Qdrant", "Hybrid + Rerank", "FastAPI"],
           url: "https://github.com/RenanMiqueloti/rag-chatbot",
+          cta: "View on GitHub",
+        },
+        {
+          label: "FEATURED",
+          title: "industrial-anomaly-detection",
+          description:
+            "Unsupervised anomaly detection on industrial time-series: Isolation Forest, OC-SVM, AutoEncoder (PyTorch) and SHAP for explainability. Bootstrap confidence intervals and Streamlit dashboard for visualization.",
+          tags: ["Python", "PyTorch", "SHAP", "Streamlit", "Anomaly Detection"],
+          url: "https://github.com/RenanMiqueloti/industrial-anomaly-detection",
+          cta: "View on GitHub",
+        },
+        {
+          label: "FEATURED",
+          title: "mcp-tools-server",
+          description:
+            "Custom MCP server with 6 utility tools exposed via stdio: datetime, calculate, text_stats, json_extract, search_knowledge and http_get. Compatible with Claude Desktop and any MCP client.",
+          tags: ["Python", "MCP", "Claude", "LangGraph"],
+          url: "https://github.com/RenanMiqueloti/mcp-tools-server",
           cta: "View on GitHub",
         },
       ],


### PR DESCRIPTION
- Adiciona `industrial-anomaly-detection` à seção `03 · projects` (PT e EN): anomaly detection não supervisionada em séries industriais com Isolation Forest, OC-SVM, AutoEncoder/PyTorch, SHAP, Streamlit.
- Adiciona `mcp-tools-server` à mesma seção: MCP server customizado com 6 tools utilitárias via stdio, compatível com Claude Desktop.
- Remove badge WIP hardcoded do card featured `agents-AI`.