### PR TITLE
feat(projects): carousel layout, terminal height fix, accurate descriptions

### DIFF
--- a/components/Sections/About.section.tsx
+++ b/components/Sections/About.section.tsx
@@ -137,16 +137,19 @@ const About = () => {
         </Reveal>
 
         <div className="mt-12 grid grid-cols-1 lg:grid-cols-[1.6fr_1fr] gap-5">
-          <Reveal delay={200}>
+          <Reveal delay={200} className="h-full">
             <Window
               title={a.terminalWindowTitle}
               hint={a.terminalHint}
+              className="h-full flex flex-col"
             >
-              <AgentTerminal height={420} />
+              <div className="flex-1 min-h-0">
+                <AgentTerminal height="100%" />
+              </div>
             </Window>
           </Reveal>
 
-          <Reveal delay={260} className="h-full">
+          <Reveal delay={260}>
             <div className="flex flex-col gap-3 h-full">
               <Window title={a.expWindowTitle}>
                 <div className="p-3.5 font-mono text-[12px] leading-[1.7]">

--- a/components/Sections/About.section.tsx
+++ b/components/Sections/About.section.tsx
@@ -137,19 +137,16 @@ const About = () => {
         </Reveal>
 
         <div className="mt-12 grid grid-cols-1 lg:grid-cols-[1.6fr_1fr] gap-5">
-          <Reveal delay={200} className="h-full">
+          <Reveal delay={200}>
             <Window
               title={a.terminalWindowTitle}
               hint={a.terminalHint}
-              className="h-full flex flex-col"
             >
-              <div className="flex-1 min-h-0">
-                <AgentTerminal height="100%" />
-              </div>
+              <AgentTerminal height={420} />
             </Window>
           </Reveal>
 
-          <Reveal delay={260}>
+          <Reveal delay={260} className="h-full">
             <div className="flex flex-col gap-3 h-full">
               <Window title={a.expWindowTitle}>
                 <div className="p-3.5 font-mono text-[12px] leading-[1.7]">

--- a/components/Sections/About.section.tsx
+++ b/components/Sections/About.section.tsx
@@ -146,7 +146,7 @@ const About = () => {
             </Window>
           </Reveal>
 
-          <Reveal delay={260}>
+          <Reveal delay={260} className="h-full">
             <div className="flex flex-col gap-3 h-full">
               <Window title={a.expWindowTitle}>
                 <div className="p-3.5 font-mono text-[12px] leading-[1.7]">

--- a/components/Sections/About.section.tsx
+++ b/components/Sections/About.section.tsx
@@ -137,12 +137,15 @@ const About = () => {
         </Reveal>
 
         <div className="mt-12 grid grid-cols-1 lg:grid-cols-[1.6fr_1fr] gap-5">
-          <Reveal delay={200}>
+          <Reveal delay={200} className="h-full">
             <Window
               title={a.terminalWindowTitle}
               hint={a.terminalHint}
+              className="h-full flex flex-col"
             >
-              <AgentTerminal height={420} />
+              <div className="flex-1 min-h-0">
+                <AgentTerminal height="100%" />
+              </div>
             </Window>
           </Reveal>
 

--- a/components/Sections/Projects.section.tsx
+++ b/components/Sections/Projects.section.tsx
@@ -29,10 +29,6 @@ const Projects = () => {
                 rel="noopener noreferrer"
                 className="group relative block h-full p-8 md:p-10 overflow-hidden hover:bg-zinc-900/30 transition-colors"
               >
-                <div className="absolute top-4 right-4 z-10 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border border-amber-500/40 bg-amber-500/10 font-mono text-[10px] uppercase tracking-[0.2em] text-amber-300">
-                  <span className="w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" />
-                  {p.comingSoonLabel}
-                </div>
                 <div className="relative">
                   <span className="font-mono text-[11px] uppercase tracking-[0.2em] text-emerald-300/90">
                     {featured.label}

--- a/components/Sections/Projects.section.tsx
+++ b/components/Sections/Projects.section.tsx
@@ -29,7 +29,7 @@ const Projects = () => {
                 rel="noopener noreferrer"
                 className="group relative block p-8 md:p-10 hover:bg-zinc-900/30 transition-colors"
               >
-                <div className="relative">
+                <div className="relative max-w-2xl mx-auto">
                   <span className="font-mono text-[11px] uppercase tracking-[0.2em] text-emerald-300/90">
                     {featured.label}
                   </span>

--- a/components/Sections/Projects.section.tsx
+++ b/components/Sections/Projects.section.tsx
@@ -1,18 +1,11 @@
-import { useState } from "react";
 import { Reveal } from "../Misc/Reveal.component";
 import { Window } from "../Misc/Window.component";
 import { useT } from "../../lib/useLocale";
-
-const PER_PAGE = 2;
 
 const Projects = () => {
   const t = useT();
   const p = t.projects;
   const featured = p.featured;
-  const [page, setPage] = useState(0);
-
-  const totalPages = Math.ceil(p.secondary.length / PER_PAGE);
-  const visible = p.secondary.slice(page * PER_PAGE, (page + 1) * PER_PAGE);
 
   return (
     <section id="projects" className="relative py-24 md:py-32 border-t border-zinc-900">
@@ -27,115 +20,87 @@ const Projects = () => {
           <p className="mt-5 max-w-xl text-zinc-400 leading-relaxed">{p.intro}</p>
         </Reveal>
 
-        <div className="mt-12 grid grid-cols-1 lg:grid-cols-2 gap-5">
-          {/* Featured */}
+        <div className="mt-12">
           <Reveal>
-            <Window title="selected-work/" className="h-full">
+            <Window title="selected-work/">
               <a
                 href={featured.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="group block h-full p-7 hover:bg-zinc-900/30 transition-colors"
+                className="group relative block p-8 md:p-10 hover:bg-zinc-900/30 transition-colors"
               >
-                <span className="font-mono text-[11px] uppercase tracking-[0.2em] text-emerald-300/90">
-                  {featured.label}
-                </span>
-                <h3 className="mt-4 font-display text-2xl md:text-3xl text-zinc-50 tracking-tight mb-3 group-hover:text-emerald-300 transition-colors">
-                  {featured.title}
-                </h3>
-                <p className="text-zinc-400 leading-relaxed text-sm">
-                  {featured.description}
-                </p>
-                <div className="mt-5 flex flex-wrap gap-2">
-                  {featured.tags.map((tag) => (
-                    <span
-                      key={tag}
-                      className="px-2.5 py-1 text-xs font-mono text-zinc-400 border border-zinc-800 rounded-md group-hover:border-emerald-500/40 transition-colors"
-                    >
-                      {tag}
-                    </span>
-                  ))}
-                </div>
-                <div className="mt-6 inline-flex items-center gap-2 text-sm text-emerald-300 font-mono">
-                  <span>$ {featured.cta.toLowerCase()}</span>
-                  <span className="transition-transform group-hover:translate-x-1">→</span>
+                <div className="relative max-w-2xl mx-auto">
+                  <span className="font-mono text-[11px] uppercase tracking-[0.2em] text-emerald-300/90">
+                    {featured.label}
+                  </span>
+                  <h3 className="mt-5 font-display text-3xl md:text-4xl text-zinc-50 tracking-tight mb-4 group-hover:text-emerald-300 transition-colors">
+                    {featured.title}
+                  </h3>
+                  <p className="text-zinc-400 max-w-2xl leading-relaxed text-[15px]">
+                    {featured.description}
+                  </p>
+                  <div className="mt-7 flex flex-wrap gap-2">
+                    {featured.tags.map((tag) => (
+                      <span
+                        key={tag}
+                        className="px-2.5 py-1 text-xs font-mono text-zinc-400 border border-zinc-800 rounded-md group-hover:border-emerald-500/40 transition-colors"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                  <div className="mt-8 inline-flex items-center gap-2 text-sm text-emerald-300 font-mono">
+                    <span>$ {featured.cta.toLowerCase()}</span>
+                    <span className="transition-transform group-hover:translate-x-1">→</span>
+                  </div>
                 </div>
               </a>
-            </Window>
-          </Reveal>
 
-          {/* Carousel */}
-          <Reveal delay={120}>
-            <Window
-              title="$ ls projects/"
-              hint={`${String(page + 1).padStart(2, "0")} / ${String(totalPages).padStart(2, "0")}`}
-              className="h-full flex flex-col"
-            >
-              <div className="flex-1 min-h-0 grid grid-cols-2 gap-px bg-zinc-800/60">
-                {visible.map((proj) => {
+              <div className="border-t border-zinc-800/60 grid grid-cols-1 md:grid-cols-3 gap-px bg-zinc-800/60">
+                {p.secondary.map((proj, i) => {
                   const isWip = proj.label === p.comingSoonLabel;
                   const isUnavailable = proj.label === p.unavailableLabel;
                   const isDisabled = isWip || isUnavailable;
                   return (
-                    <a
-                      key={proj.title}
-                      href={proj.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={`group block p-5 transition-colors overflow-auto ${
-                        isDisabled
-                          ? "opacity-45 cursor-not-allowed pointer-events-none grayscale-[40%] bg-zinc-950/85"
-                          : "bg-zinc-950/85 hover:bg-zinc-900/40"
-                      }`}
-                    >
-                      <div className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded font-mono text-[9px] uppercase tracking-[0.2em] border border-emerald-500/40 bg-emerald-500/10 text-emerald-300 mb-3">
-                        <span className="w-1 h-1 rounded-full bg-emerald-400 shadow-[0_0_6px_currentColor] animate-pulse" />
-                        {proj.label}
-                      </div>
-                      <h3 className="font-display text-base text-zinc-50 tracking-tight group-hover:text-emerald-300 transition-colors leading-snug">
-                        {proj.title}
-                      </h3>
-                      <p className="mt-2 text-xs text-zinc-400 leading-relaxed line-clamp-4">
-                        {proj.description}
-                      </p>
-                      <div className="mt-4 flex flex-wrap gap-1.5">
-                        {proj.tags.map((tag) => (
-                          <span
-                            key={tag}
-                            className="px-2 py-0.5 text-[10px] font-mono text-zinc-500 border border-zinc-800 rounded"
-                          >
-                            {tag}
-                          </span>
-                        ))}
-                      </div>
-                      <div className="mt-4 font-mono text-emerald-300 text-xs inline-flex items-center gap-1">
-                        <span>$ {proj.cta.toLowerCase()}</span>
-                        <span className="transition-transform group-hover:translate-x-1">→</span>
-                      </div>
-                    </a>
+                    <Reveal key={proj.title} delay={(i + 1) * 80} className="h-full">
+                      <a
+                        href={proj.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={`group block h-full p-6 transition-colors ${
+                          isDisabled
+                            ? "opacity-45 cursor-not-allowed pointer-events-none grayscale-[40%] bg-zinc-950/85"
+                            : "bg-zinc-950/85 hover:bg-zinc-900/40"
+                        }`}
+                      >
+                        <div className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded font-mono text-[9px] uppercase tracking-[0.2em] border border-emerald-500/40 bg-emerald-500/10 text-emerald-300 mb-4">
+                          <span className="w-1 h-1 rounded-full bg-emerald-400 shadow-[0_0_6px_currentColor] animate-pulse" />
+                          {proj.label}
+                        </div>
+                        <h3 className="font-display text-xl text-zinc-50 tracking-tight group-hover:text-emerald-300 transition-colors">
+                          {proj.title}
+                        </h3>
+                        <p className="mt-2 text-sm text-zinc-400 leading-relaxed">
+                          {proj.description}
+                        </p>
+                        <div className="mt-5 flex flex-wrap gap-1.5">
+                          {proj.tags.map((tag) => (
+                            <span
+                              key={tag}
+                              className="px-2 py-0.5 text-[11px] font-mono text-zinc-500 border border-zinc-800 rounded"
+                            >
+                              {tag}
+                            </span>
+                          ))}
+                        </div>
+                        <div className="mt-5 font-mono text-emerald-300 text-xs inline-flex items-center gap-1">
+                          <span>$ {proj.cta.toLowerCase()}</span>
+                          <span className="transition-transform group-hover:translate-x-1">→</span>
+                        </div>
+                      </a>
+                    </Reveal>
                   );
                 })}
-              </div>
-
-              {/* Navigation bar */}
-              <div className="flex items-center justify-between px-4 py-2.5 border-t border-zinc-800/60 font-mono text-xs select-none">
-                <button
-                  onClick={() => setPage((prev) => Math.max(0, prev - 1))}
-                  disabled={page === 0}
-                  className="text-zinc-500 hover:text-emerald-400 transition-colors disabled:opacity-25 disabled:cursor-not-allowed"
-                >
-                  ← prev
-                </button>
-                <span className="text-zinc-600 tracking-widest">
-                  {String(page + 1).padStart(2, "0")}&nbsp;/&nbsp;{String(totalPages).padStart(2, "0")}
-                </span>
-                <button
-                  onClick={() => setPage((prev) => Math.min(totalPages - 1, prev + 1))}
-                  disabled={page === totalPages - 1}
-                  className="text-zinc-500 hover:text-emerald-400 transition-colors disabled:opacity-25 disabled:cursor-not-allowed"
-                >
-                  next →
-                </button>
               </div>
             </Window>
           </Reveal>

--- a/components/Sections/Projects.section.tsx
+++ b/components/Sections/Projects.section.tsx
@@ -1,11 +1,18 @@
+import { useState } from "react";
 import { Reveal } from "../Misc/Reveal.component";
 import { Window } from "../Misc/Window.component";
 import { useT } from "../../lib/useLocale";
+
+const PER_PAGE = 2;
 
 const Projects = () => {
   const t = useT();
   const p = t.projects;
   const featured = p.featured;
+  const [page, setPage] = useState(0);
+
+  const totalPages = Math.ceil(p.secondary.length / PER_PAGE);
+  const visible = p.secondary.slice(page * PER_PAGE, (page + 1) * PER_PAGE);
 
   return (
     <section id="projects" className="relative py-24 md:py-32 border-t border-zinc-900">
@@ -20,87 +27,115 @@ const Projects = () => {
           <p className="mt-5 max-w-xl text-zinc-400 leading-relaxed">{p.intro}</p>
         </Reveal>
 
-        <div className="mt-12">
+        <div className="mt-12 grid grid-cols-1 lg:grid-cols-2 gap-5">
+          {/* Featured */}
           <Reveal>
-            <Window title="selected-work/">
+            <Window title="selected-work/" className="h-full">
               <a
                 href={featured.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="group relative block p-8 md:p-10 hover:bg-zinc-900/30 transition-colors"
+                className="group block h-full p-7 hover:bg-zinc-900/30 transition-colors"
               >
-                <div className="relative max-w-2xl mx-auto">
-                  <span className="font-mono text-[11px] uppercase tracking-[0.2em] text-emerald-300/90">
-                    {featured.label}
-                  </span>
-                  <h3 className="mt-5 font-display text-3xl md:text-4xl text-zinc-50 tracking-tight mb-4 group-hover:text-emerald-300 transition-colors">
-                    {featured.title}
-                  </h3>
-                  <p className="text-zinc-400 max-w-2xl leading-relaxed text-[15px]">
-                    {featured.description}
-                  </p>
-                  <div className="mt-7 flex flex-wrap gap-2">
-                    {featured.tags.map((tag) => (
-                      <span
-                        key={tag}
-                        className="px-2.5 py-1 text-xs font-mono text-zinc-400 border border-zinc-800 rounded-md group-hover:border-emerald-500/40 transition-colors"
-                      >
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
-                  <div className="mt-8 inline-flex items-center gap-2 text-sm text-emerald-300 font-mono">
-                    <span>$ {featured.cta.toLowerCase()}</span>
-                    <span className="transition-transform group-hover:translate-x-1">→</span>
-                  </div>
+                <span className="font-mono text-[11px] uppercase tracking-[0.2em] text-emerald-300/90">
+                  {featured.label}
+                </span>
+                <h3 className="mt-4 font-display text-2xl md:text-3xl text-zinc-50 tracking-tight mb-3 group-hover:text-emerald-300 transition-colors">
+                  {featured.title}
+                </h3>
+                <p className="text-zinc-400 leading-relaxed text-sm">
+                  {featured.description}
+                </p>
+                <div className="mt-5 flex flex-wrap gap-2">
+                  {featured.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="px-2.5 py-1 text-xs font-mono text-zinc-400 border border-zinc-800 rounded-md group-hover:border-emerald-500/40 transition-colors"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+                <div className="mt-6 inline-flex items-center gap-2 text-sm text-emerald-300 font-mono">
+                  <span>$ {featured.cta.toLowerCase()}</span>
+                  <span className="transition-transform group-hover:translate-x-1">→</span>
                 </div>
               </a>
+            </Window>
+          </Reveal>
 
-              <div className="border-t border-zinc-800/60 grid grid-cols-1 md:grid-cols-3 gap-px bg-zinc-800/60">
-                {p.secondary.map((proj, i) => {
+          {/* Carousel */}
+          <Reveal delay={120}>
+            <Window
+              title="$ ls projects/"
+              hint={`${String(page + 1).padStart(2, "0")} / ${String(totalPages).padStart(2, "0")}`}
+              className="h-full flex flex-col"
+            >
+              <div className="flex-1 min-h-0 grid grid-cols-2 gap-px bg-zinc-800/60">
+                {visible.map((proj) => {
                   const isWip = proj.label === p.comingSoonLabel;
                   const isUnavailable = proj.label === p.unavailableLabel;
                   const isDisabled = isWip || isUnavailable;
                   return (
-                    <Reveal key={proj.title} delay={(i + 1) * 80} className="h-full">
-                      <a
-                        href={proj.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className={`group block h-full p-6 transition-colors ${
-                          isDisabled
-                            ? "opacity-45 cursor-not-allowed pointer-events-none grayscale-[40%] bg-zinc-950/85"
-                            : "bg-zinc-950/85 hover:bg-zinc-900/40"
-                        }`}
-                      >
-                        <div className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded font-mono text-[9px] uppercase tracking-[0.2em] border border-emerald-500/40 bg-emerald-500/10 text-emerald-300 mb-4">
-                          <span className="w-1 h-1 rounded-full bg-emerald-400 shadow-[0_0_6px_currentColor] animate-pulse" />
-                          {proj.label}
-                        </div>
-                        <h3 className="font-display text-xl text-zinc-50 tracking-tight group-hover:text-emerald-300 transition-colors">
-                          {proj.title}
-                        </h3>
-                        <p className="mt-2 text-sm text-zinc-400 leading-relaxed">
-                          {proj.description}
-                        </p>
-                        <div className="mt-5 flex flex-wrap gap-1.5">
-                          {proj.tags.map((tag) => (
-                            <span
-                              key={tag}
-                              className="px-2 py-0.5 text-[11px] font-mono text-zinc-500 border border-zinc-800 rounded"
-                            >
-                              {tag}
-                            </span>
-                          ))}
-                        </div>
-                        <div className="mt-5 font-mono text-emerald-300 text-xs inline-flex items-center gap-1">
-                          <span>$ {proj.cta.toLowerCase()}</span>
-                          <span className="transition-transform group-hover:translate-x-1">→</span>
-                        </div>
-                      </a>
-                    </Reveal>
+                    <a
+                      key={proj.title}
+                      href={proj.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={`group block p-5 transition-colors overflow-auto ${
+                        isDisabled
+                          ? "opacity-45 cursor-not-allowed pointer-events-none grayscale-[40%] bg-zinc-950/85"
+                          : "bg-zinc-950/85 hover:bg-zinc-900/40"
+                      }`}
+                    >
+                      <div className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded font-mono text-[9px] uppercase tracking-[0.2em] border border-emerald-500/40 bg-emerald-500/10 text-emerald-300 mb-3">
+                        <span className="w-1 h-1 rounded-full bg-emerald-400 shadow-[0_0_6px_currentColor] animate-pulse" />
+                        {proj.label}
+                      </div>
+                      <h3 className="font-display text-base text-zinc-50 tracking-tight group-hover:text-emerald-300 transition-colors leading-snug">
+                        {proj.title}
+                      </h3>
+                      <p className="mt-2 text-xs text-zinc-400 leading-relaxed line-clamp-4">
+                        {proj.description}
+                      </p>
+                      <div className="mt-4 flex flex-wrap gap-1.5">
+                        {proj.tags.map((tag) => (
+                          <span
+                            key={tag}
+                            className="px-2 py-0.5 text-[10px] font-mono text-zinc-500 border border-zinc-800 rounded"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                      <div className="mt-4 font-mono text-emerald-300 text-xs inline-flex items-center gap-1">
+                        <span>$ {proj.cta.toLowerCase()}</span>
+                        <span className="transition-transform group-hover:translate-x-1">→</span>
+                      </div>
+                    </a>
                   );
                 })}
+              </div>
+
+              {/* Navigation bar */}
+              <div className="flex items-center justify-between px-4 py-2.5 border-t border-zinc-800/60 font-mono text-xs select-none">
+                <button
+                  onClick={() => setPage((prev) => Math.max(0, prev - 1))}
+                  disabled={page === 0}
+                  className="text-zinc-500 hover:text-emerald-400 transition-colors disabled:opacity-25 disabled:cursor-not-allowed"
+                >
+                  ← prev
+                </button>
+                <span className="text-zinc-600 tracking-widest">
+                  {String(page + 1).padStart(2, "0")}&nbsp;/&nbsp;{String(totalPages).padStart(2, "0")}
+                </span>
+                <button
+                  onClick={() => setPage((prev) => Math.min(totalPages - 1, prev + 1))}
+                  disabled={page === totalPages - 1}
+                  className="text-zinc-500 hover:text-emerald-400 transition-colors disabled:opacity-25 disabled:cursor-not-allowed"
+                >
+                  next →
+                </button>
               </div>
             </Window>
           </Reveal>

--- a/components/Sections/Projects.section.tsx
+++ b/components/Sections/Projects.section.tsx
@@ -20,14 +20,14 @@ const Projects = () => {
           <p className="mt-5 max-w-xl text-zinc-400 leading-relaxed">{p.intro}</p>
         </Reveal>
 
-        <div className="mt-12 grid grid-cols-1 lg:grid-cols-3 gap-5">
+        <div className="mt-12">
           <Reveal>
-            <Window title="agents-and-ai/" className="h-full lg:col-span-2">
+            <Window title="selected-work/">
               <a
                 href={featured.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="group relative block h-full p-8 md:p-10 overflow-hidden hover:bg-zinc-900/30 transition-colors"
+                className="group relative block p-8 md:p-10 hover:bg-zinc-900/30 transition-colors"
               >
                 <div className="relative">
                   <span className="font-mono text-[11px] uppercase tracking-[0.2em] text-emerald-300/90">
@@ -55,42 +55,35 @@ const Projects = () => {
                   </div>
                 </div>
               </a>
-            </Window>
-          </Reveal>
 
-          <div className="flex flex-col gap-5">
-            {p.secondary.map((proj, i) => {
-              const isWip = proj.label === p.comingSoonLabel;
-              const isUnavailable = proj.label === p.unavailableLabel;
-              const isDisabled = isWip || isUnavailable;
-              const baseCard = "group relative block p-6 bg-zinc-950/60 border border-zinc-800/80 rounded-lg min-h-[160px] transition-all";
-              const cardCls = `${baseCard} ${isDisabled ? "opacity-45 hover:opacity-60 cursor-not-allowed pointer-events-none grayscale-[40%]" : "hover:border-emerald-500/40 hover:bg-zinc-900/30"}`;
-              const baseBadge = "absolute top-3 right-3 inline-flex items-center gap-1.5 px-2 py-0.5 rounded font-mono text-[9px] uppercase tracking-[0.2em]";
-              const badgeCls = `${baseBadge} ${isDisabled ? "border border-zinc-600/40 bg-zinc-700/10 text-zinc-400" : "border border-emerald-500/40 bg-emerald-500/10 text-emerald-300"}`;
-              const dotCls = isDisabled
-                ? "w-1 h-1 rounded-full bg-zinc-500"
-                : "w-1 h-1 rounded-full bg-emerald-400 shadow-[0_0_6px_currentColor] animate-pulse";
-              return (
-                <Reveal key={proj.title} delay={(i + 1) * 80}>
-                  <a
-                    href={proj.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={cardCls}
-                  >
-                    <div className={badgeCls}>
-                      <span className={dotCls} />
-                      {proj.label}
-                    </div>
-                    <div>
-                      <h3 className="mt-3 font-display text-2xl text-zinc-50 tracking-tight group-hover:text-emerald-300 transition-colors">
-                        {proj.title}
-                      </h3>
-                      <p className="mt-2 text-sm text-zinc-400 leading-relaxed">
-                        {proj.description}
-                      </p>
-                      <div className="mt-5 flex items-center justify-between gap-3">
-                        <div className="flex flex-wrap gap-1.5">
+              <div className="border-t border-zinc-800/60 grid grid-cols-1 md:grid-cols-3 gap-px bg-zinc-800/60">
+                {p.secondary.map((proj, i) => {
+                  const isWip = proj.label === p.comingSoonLabel;
+                  const isUnavailable = proj.label === p.unavailableLabel;
+                  const isDisabled = isWip || isUnavailable;
+                  return (
+                    <Reveal key={proj.title} delay={(i + 1) * 80} className="h-full">
+                      <a
+                        href={proj.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={`group block h-full p-6 transition-colors ${
+                          isDisabled
+                            ? "opacity-45 cursor-not-allowed pointer-events-none grayscale-[40%] bg-zinc-950/85"
+                            : "bg-zinc-950/85 hover:bg-zinc-900/40"
+                        }`}
+                      >
+                        <div className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded font-mono text-[9px] uppercase tracking-[0.2em] border border-emerald-500/40 bg-emerald-500/10 text-emerald-300 mb-4">
+                          <span className="w-1 h-1 rounded-full bg-emerald-400 shadow-[0_0_6px_currentColor] animate-pulse" />
+                          {proj.label}
+                        </div>
+                        <h3 className="font-display text-xl text-zinc-50 tracking-tight group-hover:text-emerald-300 transition-colors">
+                          {proj.title}
+                        </h3>
+                        <p className="mt-2 text-sm text-zinc-400 leading-relaxed">
+                          {proj.description}
+                        </p>
+                        <div className="mt-5 flex flex-wrap gap-1.5">
                           {proj.tags.map((tag) => (
                             <span
                               key={tag}
@@ -100,17 +93,17 @@ const Projects = () => {
                             </span>
                           ))}
                         </div>
-                        <span className="font-mono text-emerald-300 text-xs inline-flex items-center gap-1">
-                          $ {proj.cta.toLowerCase()}
+                        <div className="mt-5 font-mono text-emerald-300 text-xs inline-flex items-center gap-1">
+                          <span>$ {proj.cta.toLowerCase()}</span>
                           <span className="transition-transform group-hover:translate-x-1">→</span>
-                        </span>
-                      </div>
-                    </div>
-                  </a>
-                </Reveal>
-              );
-            })}
-          </div>
+                        </div>
+                      </a>
+                    </Reveal>
+                  );
+                })}
+              </div>
+            </Window>
+          </Reveal>
         </div>
 
         <Reveal delay={120}>

--- a/components/Sections/Projects.section.tsx
+++ b/components/Sections/Projects.section.tsx
@@ -1,11 +1,18 @@
+import { useState } from "react";
 import { Reveal } from "../Misc/Reveal.component";
 import { Window } from "../Misc/Window.component";
 import { useT } from "../../lib/useLocale";
+
+const PER_PAGE = 2;
 
 const Projects = () => {
   const t = useT();
   const p = t.projects;
   const featured = p.featured;
+  const [page, setPage] = useState(0);
+
+  const totalPages = Math.ceil(p.secondary.length / PER_PAGE);
+  const visible = p.secondary.slice(page * PER_PAGE, (page + 1) * PER_PAGE);
 
   return (
     <section id="projects" className="relative py-24 md:py-32 border-t border-zinc-900">
@@ -20,87 +27,114 @@ const Projects = () => {
           <p className="mt-5 max-w-xl text-zinc-400 leading-relaxed">{p.intro}</p>
         </Reveal>
 
-        <div className="mt-12">
+        <div className="mt-12 grid grid-cols-1 lg:grid-cols-2 gap-5">
+          {/* Featured — left */}
           <Reveal>
-            <Window title="selected-work/">
+            <Window title="selected-work/" className="h-full">
               <a
                 href={featured.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="group relative block p-8 md:p-10 hover:bg-zinc-900/30 transition-colors"
+                className="group block h-full p-7 hover:bg-zinc-900/30 transition-colors"
               >
-                <div className="relative max-w-2xl mx-auto">
-                  <span className="font-mono text-[11px] uppercase tracking-[0.2em] text-emerald-300/90">
-                    {featured.label}
-                  </span>
-                  <h3 className="mt-5 font-display text-3xl md:text-4xl text-zinc-50 tracking-tight mb-4 group-hover:text-emerald-300 transition-colors">
-                    {featured.title}
-                  </h3>
-                  <p className="text-zinc-400 max-w-2xl leading-relaxed text-[15px]">
-                    {featured.description}
-                  </p>
-                  <div className="mt-7 flex flex-wrap gap-2">
-                    {featured.tags.map((tag) => (
-                      <span
-                        key={tag}
-                        className="px-2.5 py-1 text-xs font-mono text-zinc-400 border border-zinc-800 rounded-md group-hover:border-emerald-500/40 transition-colors"
-                      >
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
-                  <div className="mt-8 inline-flex items-center gap-2 text-sm text-emerald-300 font-mono">
-                    <span>$ {featured.cta.toLowerCase()}</span>
-                    <span className="transition-transform group-hover:translate-x-1">→</span>
-                  </div>
+                <span className="font-mono text-[11px] uppercase tracking-[0.2em] text-emerald-300/90">
+                  {featured.label}
+                </span>
+                <h3 className="mt-5 font-display text-3xl md:text-4xl text-zinc-50 tracking-tight mb-4 group-hover:text-emerald-300 transition-colors">
+                  {featured.title}
+                </h3>
+                <p className="text-zinc-400 leading-relaxed text-[15px] line-clamp-4">
+                  {featured.description}
+                </p>
+                <div className="mt-7 flex flex-wrap gap-2">
+                  {featured.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="px-2.5 py-1 text-xs font-mono text-zinc-400 border border-zinc-800 rounded-md group-hover:border-emerald-500/40 transition-colors"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+                <div className="mt-8 inline-flex items-center gap-2 text-sm text-emerald-300 font-mono">
+                  <span>$ {featured.cta.toLowerCase()}</span>
+                  <span className="transition-transform group-hover:translate-x-1">→</span>
                 </div>
               </a>
+            </Window>
+          </Reveal>
 
-              <div className="border-t border-zinc-800/60 grid grid-cols-1 md:grid-cols-3 gap-px bg-zinc-800/60">
-                {p.secondary.map((proj, i) => {
+          {/* Carousel — right */}
+          <Reveal delay={120}>
+            <Window
+              title="$ ls projects/"
+              hint={`${String(page + 1).padStart(2, "0")} / ${String(totalPages).padStart(2, "0")}`}
+              className="h-full flex flex-col"
+            >
+              <div className="flex-1 min-h-0 grid grid-cols-2 gap-px bg-zinc-800/60">
+                {visible.map((proj) => {
                   const isWip = proj.label === p.comingSoonLabel;
                   const isUnavailable = proj.label === p.unavailableLabel;
                   const isDisabled = isWip || isUnavailable;
                   return (
-                    <Reveal key={proj.title} delay={(i + 1) * 80} className="h-full">
-                      <a
-                        href={proj.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className={`group block h-full p-6 transition-colors ${
-                          isDisabled
-                            ? "opacity-45 cursor-not-allowed pointer-events-none grayscale-[40%] bg-zinc-950/85"
-                            : "bg-zinc-950/85 hover:bg-zinc-900/40"
-                        }`}
-                      >
-                        <div className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded font-mono text-[9px] uppercase tracking-[0.2em] border border-emerald-500/40 bg-emerald-500/10 text-emerald-300 mb-4">
-                          <span className="w-1 h-1 rounded-full bg-emerald-400 shadow-[0_0_6px_currentColor] animate-pulse" />
-                          {proj.label}
-                        </div>
-                        <h3 className="font-display text-xl text-zinc-50 tracking-tight group-hover:text-emerald-300 transition-colors">
-                          {proj.title}
-                        </h3>
-                        <p className="mt-2 text-sm text-zinc-400 leading-relaxed">
-                          {proj.description}
-                        </p>
-                        <div className="mt-5 flex flex-wrap gap-1.5">
-                          {proj.tags.map((tag) => (
-                            <span
-                              key={tag}
-                              className="px-2 py-0.5 text-[11px] font-mono text-zinc-500 border border-zinc-800 rounded"
-                            >
-                              {tag}
-                            </span>
-                          ))}
-                        </div>
-                        <div className="mt-5 font-mono text-emerald-300 text-xs inline-flex items-center gap-1">
-                          <span>$ {proj.cta.toLowerCase()}</span>
-                          <span className="transition-transform group-hover:translate-x-1">→</span>
-                        </div>
-                      </a>
-                    </Reveal>
+                    <a
+                      key={proj.title}
+                      href={proj.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={`group block p-5 transition-colors ${
+                        isDisabled
+                          ? "opacity-45 cursor-not-allowed pointer-events-none grayscale-[40%] bg-zinc-950/85"
+                          : "bg-zinc-950/85 hover:bg-zinc-900/40"
+                      }`}
+                    >
+                      <div className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded font-mono text-[9px] uppercase tracking-[0.2em] border border-emerald-500/40 bg-emerald-500/10 text-emerald-300 mb-3">
+                        <span className="w-1 h-1 rounded-full bg-emerald-400 shadow-[0_0_6px_currentColor] animate-pulse" />
+                        {proj.label}
+                      </div>
+                      <h3 className="font-display text-lg text-zinc-50 tracking-tight group-hover:text-emerald-300 transition-colors leading-tight">
+                        {proj.title}
+                      </h3>
+                      <p className="mt-2 text-xs text-zinc-400 leading-relaxed line-clamp-4">
+                        {proj.description}
+                      </p>
+                      <div className="mt-4 flex flex-wrap gap-1.5">
+                        {proj.tags.map((tag) => (
+                          <span
+                            key={tag}
+                            className="px-2 py-0.5 text-[10px] font-mono text-zinc-500 border border-zinc-800 rounded"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                      <div className="mt-4 font-mono text-emerald-300 text-xs inline-flex items-center gap-1">
+                        <span>$ {proj.cta.toLowerCase()}</span>
+                        <span className="transition-transform group-hover:translate-x-1">→</span>
+                      </div>
+                    </a>
                   );
                 })}
+              </div>
+
+              <div className="flex items-center justify-between px-4 py-2.5 border-t border-zinc-800/60 font-mono text-xs select-none">
+                <button
+                  onClick={() => setPage((prev) => Math.max(0, prev - 1))}
+                  disabled={page === 0}
+                  className="text-zinc-500 hover:text-emerald-400 disabled:opacity-25 disabled:cursor-not-allowed transition-colors"
+                >
+                  ← prev
+                </button>
+                <span className="text-zinc-600 tracking-widest">
+                  {String(page + 1).padStart(2, "0")}&nbsp;/&nbsp;{String(totalPages).padStart(2, "0")}
+                </span>
+                <button
+                  onClick={() => setPage((prev) => Math.min(totalPages - 1, prev + 1))}
+                  disabled={page === totalPages - 1}
+                  className="text-zinc-500 hover:text-emerald-400 disabled:opacity-25 disabled:cursor-not-allowed transition-colors"
+                >
+                  next →
+                </button>
               </div>
             </Window>
           </Reveal>

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -255,7 +255,7 @@ export const MESSAGES: Record<Locale, Messages> = {
         description:
           "Referência de padrões de produção para agentes de IA: MCP server customizado com 4 ferramentas expostas via stdio, LangGraph HITL, multi-provider (Ollama / Claude / OpenAI) e evals com LLM-as-judge — tudo em um único repositório executável.",
         tags: ["LangGraph", "MCP", "LangChain", "RAG", "Evals"],
-        url: "https://github.com/RenanMiqueloti/agents-AI",
+        url: SHARED_FEATURED_URL,
         cta: "Ver no GitHub",
       },
       secondary: [
@@ -477,7 +477,7 @@ export const MESSAGES: Record<Locale, Messages> = {
         description:
           "Production patterns reference for AI agents: custom MCP server with 4 tools exposed via stdio, LangGraph HITL, multi-provider (Ollama / Claude / OpenAI) and LLM-as-judge evals — all in a single runnable repository.",
         tags: ["LangGraph", "MCP", "LangChain", "RAG", "Evals"],
-        url: "https://github.com/RenanMiqueloti/agents-AI",
+        url: SHARED_FEATURED_URL,
         cta: "View on GitHub",
       },
       secondary: [

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -256,18 +256,9 @@ export const MESSAGES: Record<Locale, Messages> = {
           "Referência de padrões de produção para agentes de IA: MCP server customizado com 4 ferramentas expostas via stdio, LangGraph HITL, multi-provider (Ollama / Claude / OpenAI) e evals com LLM-as-judge — tudo em um único repositório executável.",
         tags: ["LangGraph", "MCP", "LangChain", "RAG", "Evals"],
         url: SHARED_FEATURED_URL,
-        cta: "Ver no GitHub",
+        cta: "Ver perfil no GitHub",
       },
       secondary: [
-        {
-          label: "DESTAQUE",
-          title: "rag-chatbot",
-          description:
-            "Pipeline RAG de produção com LangGraph orquestrando retrieve → rerank → generate. Hybrid retrieval BM25 + semantic com RRF, cross-encoder re-ranking, FastAPI streaming e harness de evals com LLM-as-judge (relevância, faithfulness, completeness).",
-          tags: ["LangGraph", "Qdrant", "Hybrid + Rerank", "FastAPI"],
-          url: "https://github.com/RenanMiqueloti/rag-chatbot",
-          cta: "Ver no GitHub",
-        },
         {
           label: "DESTAQUE",
           title: "industrial-anomaly-detection",
@@ -275,6 +266,15 @@ export const MESSAGES: Record<Locale, Messages> = {
             "Detecção de anomalias não supervisionada em séries temporais industriais: Isolation Forest, OC-SVM, AutoEncoder (PyTorch) e SHAP para explicabilidade. Bootstrap CI e dashboard Streamlit para visualização.",
           tags: ["Python", "PyTorch", "SHAP", "Streamlit", "Anomaly Detection"],
           url: "https://github.com/RenanMiqueloti/industrial-anomaly-detection",
+          cta: "Ver no GitHub",
+        },
+        {
+          label: "DESTAQUE",
+          title: "rag-chatbot",
+          description:
+            "Pipeline RAG de produção com LangGraph orquestrando retrieve → rerank → generate. Hybrid retrieval BM25 + semantic com RRF, cross-encoder re-ranking, FastAPI streaming e harness de evals com LLM-as-judge (relevância, faithfulness, completeness).",
+          tags: ["LangGraph", "Qdrant", "Hybrid + Rerank", "FastAPI"],
+          url: "https://github.com/RenanMiqueloti/rag-chatbot",
           cta: "Ver no GitHub",
         },
         {
@@ -478,18 +478,9 @@ export const MESSAGES: Record<Locale, Messages> = {
           "Production patterns reference for AI agents: custom MCP server with 4 tools exposed via stdio, LangGraph HITL, multi-provider (Ollama / Claude / OpenAI) and LLM-as-judge evals — all in a single runnable repository.",
         tags: ["LangGraph", "MCP", "LangChain", "RAG", "Evals"],
         url: SHARED_FEATURED_URL,
-        cta: "View on GitHub",
+        cta: "View GitHub profile",
       },
       secondary: [
-        {
-          label: "FEATURED",
-          title: "rag-chatbot",
-          description:
-            "Production RAG pipeline with LangGraph orchestrating retrieve → rerank → generate. Hybrid retrieval BM25 + semantic with RRF, cross-encoder re-ranking, FastAPI streaming and an LLM-as-judge eval harness (relevance, faithfulness, completeness).",
-          tags: ["LangGraph", "Qdrant", "Hybrid + Rerank", "FastAPI"],
-          url: "https://github.com/RenanMiqueloti/rag-chatbot",
-          cta: "View on GitHub",
-        },
         {
           label: "FEATURED",
           title: "industrial-anomaly-detection",
@@ -497,6 +488,15 @@ export const MESSAGES: Record<Locale, Messages> = {
             "Unsupervised anomaly detection on industrial time-series: Isolation Forest, OC-SVM, AutoEncoder (PyTorch) and SHAP for explainability. Bootstrap confidence intervals and Streamlit dashboard for visualization.",
           tags: ["Python", "PyTorch", "SHAP", "Streamlit", "Anomaly Detection"],
           url: "https://github.com/RenanMiqueloti/industrial-anomaly-detection",
+          cta: "View on GitHub",
+        },
+        {
+          label: "FEATURED",
+          title: "rag-chatbot",
+          description:
+            "Production RAG pipeline with LangGraph orchestrating retrieve → rerank → generate. Hybrid retrieval BM25 + semantic with RRF, cross-encoder re-ranking, FastAPI streaming and an LLM-as-judge eval harness (relevance, faithfulness, completeness).",
+          tags: ["LangGraph", "Qdrant", "Hybrid + Rerank", "FastAPI"],
+          url: "https://github.com/RenanMiqueloti/rag-chatbot",
           cta: "View on GitHub",
         },
         {

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -253,12 +253,21 @@ export const MESSAGES: Record<Locale, Messages> = {
         label: "DESTAQUE",
         title: "agents-AI",
         description:
-          "Referência de padrões de produção para agentes de IA: MCP server customizado com 4 ferramentas expostas via stdio, LangGraph HITL, multi-provider (Ollama / Claude / OpenAI) e evals com LLM-as-judge — tudo em um único repositório executável.",
+          "Referência de padrões de produção para agentes de IA: MCP server customizado com 4 ferramentas expostas via stdio, LangGraph HITL e multi-provider (Ollama / Claude / OpenAI) — tudo em um único repositório executável.",
         tags: ["LangGraph", "MCP", "LangChain", "RAG", "Evals"],
         url: SHARED_FEATURED_URL,
-        cta: "Ver no GitHub",
+        cta: "Ver perfil no GitHub",
       },
       secondary: [
+        {
+          label: "DESTAQUE",
+          title: "industrial-anomaly-detection",
+          description:
+            "Detecção de anomalias não supervisionada em séries temporais industriais (dataset IMS/NASA): Isolation Forest, LOF, OC-SVM, AutoEncoder (PyTorch) e SHAP para explicabilidade. Bootstrap CI e dashboard Streamlit para visualização.",
+          tags: ["Python", "PyTorch", "SHAP", "Streamlit", "Anomaly Detection"],
+          url: "https://github.com/RenanMiqueloti/industrial-anomaly-detection",
+          cta: "Ver no GitHub",
+        },
         {
           label: "DESTAQUE",
           title: "rag-chatbot",
@@ -266,15 +275,6 @@ export const MESSAGES: Record<Locale, Messages> = {
             "Pipeline RAG de produção com LangGraph orquestrando retrieve → rerank → generate. Hybrid retrieval BM25 + semantic com RRF, cross-encoder re-ranking, FastAPI streaming e harness de evals com LLM-as-judge (relevância, faithfulness, completeness).",
           tags: ["LangGraph", "Qdrant", "Hybrid + Rerank", "FastAPI"],
           url: "https://github.com/RenanMiqueloti/rag-chatbot",
-          cta: "Ver no GitHub",
-        },
-        {
-          label: "DESTAQUE",
-          title: "industrial-anomaly-detection",
-          description:
-            "Detecção de anomalias não supervisionada em séries temporais industriais: Isolation Forest, OC-SVM, AutoEncoder (PyTorch) e SHAP para explicabilidade. Bootstrap CI e dashboard Streamlit para visualização.",
-          tags: ["Python", "PyTorch", "SHAP", "Streamlit", "Anomaly Detection"],
-          url: "https://github.com/RenanMiqueloti/industrial-anomaly-detection",
           cta: "Ver no GitHub",
         },
         {
@@ -475,12 +475,21 @@ export const MESSAGES: Record<Locale, Messages> = {
         label: "FEATURED",
         title: "agents-AI",
         description:
-          "Production patterns reference for AI agents: custom MCP server with 4 tools exposed via stdio, LangGraph HITL, multi-provider (Ollama / Claude / OpenAI) and LLM-as-judge evals — all in a single runnable repository.",
+          "Production patterns reference for AI agents: custom MCP server with 4 tools exposed via stdio, LangGraph HITL and multi-provider (Ollama / Claude / OpenAI) — all in a single runnable repository.",
         tags: ["LangGraph", "MCP", "LangChain", "RAG", "Evals"],
         url: SHARED_FEATURED_URL,
-        cta: "View on GitHub",
+        cta: "View GitHub profile",
       },
       secondary: [
+        {
+          label: "FEATURED",
+          title: "industrial-anomaly-detection",
+          description:
+            "Unsupervised anomaly detection on industrial time-series (IMS/NASA dataset): Isolation Forest, LOF, OC-SVM, AutoEncoder (PyTorch) and SHAP for explainability. Bootstrap confidence intervals and Streamlit dashboard for visualization.",
+          tags: ["Python", "PyTorch", "SHAP", "Streamlit", "Anomaly Detection"],
+          url: "https://github.com/RenanMiqueloti/industrial-anomaly-detection",
+          cta: "View on GitHub",
+        },
         {
           label: "FEATURED",
           title: "rag-chatbot",
@@ -488,15 +497,6 @@ export const MESSAGES: Record<Locale, Messages> = {
             "Production RAG pipeline with LangGraph orchestrating retrieve → rerank → generate. Hybrid retrieval BM25 + semantic with RRF, cross-encoder re-ranking, FastAPI streaming and an LLM-as-judge eval harness (relevance, faithfulness, completeness).",
           tags: ["LangGraph", "Qdrant", "Hybrid + Rerank", "FastAPI"],
           url: "https://github.com/RenanMiqueloti/rag-chatbot",
-          cta: "View on GitHub",
-        },
-        {
-          label: "FEATURED",
-          title: "industrial-anomaly-detection",
-          description:
-            "Unsupervised anomaly detection on industrial time-series: Isolation Forest, OC-SVM, AutoEncoder (PyTorch) and SHAP for explainability. Bootstrap confidence intervals and Streamlit dashboard for visualization.",
-          tags: ["Python", "PyTorch", "SHAP", "Streamlit", "Anomaly Detection"],
-          url: "https://github.com/RenanMiqueloti/industrial-anomaly-detection",
           cta: "View on GitHub",
         },
         {

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -268,6 +268,24 @@ export const MESSAGES: Record<Locale, Messages> = {
           url: "https://github.com/RenanMiqueloti/rag-chatbot",
           cta: "Ver no GitHub",
         },
+        {
+          label: "DESTAQUE",
+          title: "industrial-anomaly-detection",
+          description:
+            "Detecção de anomalias não supervisionada em séries temporais industriais: Isolation Forest, OC-SVM, AutoEncoder (PyTorch) e SHAP para explicabilidade. Bootstrap CI e dashboard Streamlit para visualização.",
+          tags: ["Python", "PyTorch", "SHAP", "Streamlit", "Anomaly Detection"],
+          url: "https://github.com/RenanMiqueloti/industrial-anomaly-detection",
+          cta: "Ver no GitHub",
+        },
+        {
+          label: "DESTAQUE",
+          title: "mcp-tools-server",
+          description:
+            "MCP server customizado com 6 ferramentas utilitárias expostas via stdio: datetime, calculate, text_stats, json_extract, search_knowledge e http_get. Compatível com Claude Desktop e qualquer cliente MCP.",
+          tags: ["Python", "MCP", "Claude", "LangGraph"],
+          url: "https://github.com/RenanMiqueloti/mcp-tools-server",
+          cta: "Ver no GitHub",
+        },
       ],
       seeAllCta: "$ ver todos os repos no GitHub",
       seeAllUrl: SHARED_FEATURED_URL,
@@ -470,6 +488,24 @@ export const MESSAGES: Record<Locale, Messages> = {
             "Production RAG pipeline with LangGraph orchestrating retrieve → rerank → generate. Hybrid retrieval BM25 + semantic with RRF, cross-encoder re-ranking, FastAPI streaming and an LLM-as-judge eval harness (relevance, faithfulness, completeness).",
           tags: ["LangGraph", "Qdrant", "Hybrid + Rerank", "FastAPI"],
           url: "https://github.com/RenanMiqueloti/rag-chatbot",
+          cta: "View on GitHub",
+        },
+        {
+          label: "FEATURED",
+          title: "industrial-anomaly-detection",
+          description:
+            "Unsupervised anomaly detection on industrial time-series: Isolation Forest, OC-SVM, AutoEncoder (PyTorch) and SHAP for explainability. Bootstrap confidence intervals and Streamlit dashboard for visualization.",
+          tags: ["Python", "PyTorch", "SHAP", "Streamlit", "Anomaly Detection"],
+          url: "https://github.com/RenanMiqueloti/industrial-anomaly-detection",
+          cta: "View on GitHub",
+        },
+        {
+          label: "FEATURED",
+          title: "mcp-tools-server",
+          description:
+            "Custom MCP server with 6 utility tools exposed via stdio: datetime, calculate, text_stats, json_extract, search_knowledge and http_get. Compatible with Claude Desktop and any MCP client.",
+          tags: ["Python", "MCP", "Claude", "LangGraph"],
+          url: "https://github.com/RenanMiqueloti/mcp-tools-server",
           cta: "View on GitHub",
         },
       ],

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -256,18 +256,9 @@ export const MESSAGES: Record<Locale, Messages> = {
           "Referência de padrões de produção para agentes de IA: MCP server customizado com 4 ferramentas expostas via stdio, LangGraph HITL, multi-provider (Ollama / Claude / OpenAI) e evals com LLM-as-judge — tudo em um único repositório executável.",
         tags: ["LangGraph", "MCP", "LangChain", "RAG", "Evals"],
         url: SHARED_FEATURED_URL,
-        cta: "Ver perfil no GitHub",
+        cta: "Ver no GitHub",
       },
       secondary: [
-        {
-          label: "DESTAQUE",
-          title: "industrial-anomaly-detection",
-          description:
-            "Detecção de anomalias não supervisionada em séries temporais industriais: Isolation Forest, OC-SVM, AutoEncoder (PyTorch) e SHAP para explicabilidade. Bootstrap CI e dashboard Streamlit para visualização.",
-          tags: ["Python", "PyTorch", "SHAP", "Streamlit", "Anomaly Detection"],
-          url: "https://github.com/RenanMiqueloti/industrial-anomaly-detection",
-          cta: "Ver no GitHub",
-        },
         {
           label: "DESTAQUE",
           title: "rag-chatbot",
@@ -275,6 +266,15 @@ export const MESSAGES: Record<Locale, Messages> = {
             "Pipeline RAG de produção com LangGraph orquestrando retrieve → rerank → generate. Hybrid retrieval BM25 + semantic com RRF, cross-encoder re-ranking, FastAPI streaming e harness de evals com LLM-as-judge (relevância, faithfulness, completeness).",
           tags: ["LangGraph", "Qdrant", "Hybrid + Rerank", "FastAPI"],
           url: "https://github.com/RenanMiqueloti/rag-chatbot",
+          cta: "Ver no GitHub",
+        },
+        {
+          label: "DESTAQUE",
+          title: "industrial-anomaly-detection",
+          description:
+            "Detecção de anomalias não supervisionada em séries temporais industriais: Isolation Forest, OC-SVM, AutoEncoder (PyTorch) e SHAP para explicabilidade. Bootstrap CI e dashboard Streamlit para visualização.",
+          tags: ["Python", "PyTorch", "SHAP", "Streamlit", "Anomaly Detection"],
+          url: "https://github.com/RenanMiqueloti/industrial-anomaly-detection",
           cta: "Ver no GitHub",
         },
         {
@@ -478,18 +478,9 @@ export const MESSAGES: Record<Locale, Messages> = {
           "Production patterns reference for AI agents: custom MCP server with 4 tools exposed via stdio, LangGraph HITL, multi-provider (Ollama / Claude / OpenAI) and LLM-as-judge evals — all in a single runnable repository.",
         tags: ["LangGraph", "MCP", "LangChain", "RAG", "Evals"],
         url: SHARED_FEATURED_URL,
-        cta: "View GitHub profile",
+        cta: "View on GitHub",
       },
       secondary: [
-        {
-          label: "FEATURED",
-          title: "industrial-anomaly-detection",
-          description:
-            "Unsupervised anomaly detection on industrial time-series: Isolation Forest, OC-SVM, AutoEncoder (PyTorch) and SHAP for explainability. Bootstrap confidence intervals and Streamlit dashboard for visualization.",
-          tags: ["Python", "PyTorch", "SHAP", "Streamlit", "Anomaly Detection"],
-          url: "https://github.com/RenanMiqueloti/industrial-anomaly-detection",
-          cta: "View on GitHub",
-        },
         {
           label: "FEATURED",
           title: "rag-chatbot",
@@ -497,6 +488,15 @@ export const MESSAGES: Record<Locale, Messages> = {
             "Production RAG pipeline with LangGraph orchestrating retrieve → rerank → generate. Hybrid retrieval BM25 + semantic with RRF, cross-encoder re-ranking, FastAPI streaming and an LLM-as-judge eval harness (relevance, faithfulness, completeness).",
           tags: ["LangGraph", "Qdrant", "Hybrid + Rerank", "FastAPI"],
           url: "https://github.com/RenanMiqueloti/rag-chatbot",
+          cta: "View on GitHub",
+        },
+        {
+          label: "FEATURED",
+          title: "industrial-anomaly-detection",
+          description:
+            "Unsupervised anomaly detection on industrial time-series: Isolation Forest, OC-SVM, AutoEncoder (PyTorch) and SHAP for explainability. Bootstrap confidence intervals and Streamlit dashboard for visualization.",
+          tags: ["Python", "PyTorch", "SHAP", "Streamlit", "Anomaly Detection"],
+          url: "https://github.com/RenanMiqueloti/industrial-anomaly-detection",
           cta: "View on GitHub",
         },
         {


### PR DESCRIPTION
- Substitui grid de cards secundários por carrossel horizontal paginado (2 cards/página, nav `← prev / next →` em estilo terminal) num split 50/50 com o card featured.
- Featured card aponta pro perfil GitHub; CTA atualizado.
- Reordena: `industrial-anomaly-detection` primeiro, `rag-chatbot` segundo.
- About: terminal estica pra altura total da coluna direita (`flex-1 min-h-0` + `height="100%"`).
- Descrição do `agents-AI`: tira menção a LLM-as-judge evals (não implementado no código).
- Descrição do `industrial-anomaly`: adiciona referência ao IMS/NASA e LOF na lista de modelos.

Testado em localhost:3000 PT/EN; carousel pagina, descrições e CTAs corretas em ambos locales.