### PR TITLE
feat(projects): industrial-anomaly-detection card → live demo + clearer copy

### DIFF
--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -259,12 +259,12 @@ export const MESSAGES: Record<Locale, Messages> = {
       secondary: [
         {
           label: "DESTAQUE",
-          title: "industrial-anomaly-detection",
+          title: "Manutenção preditiva — falhas em rolamentos",
           description:
-            "Detecção de anomalias não supervisionada em séries temporais industriais (dataset IMS/NASA): Isolation Forest, LOF, OC-SVM, AutoEncoder (PyTorch) e SHAP para explicabilidade. Intervalos de confiança via bootstrap e dashboard Streamlit para visualização.",
-          tags: ["Python", "PyTorch", "SHAP", "Streamlit", "Anomaly Detection"],
-          url: "https://github.com/RenanMiqueloti/industrial-anomaly-detection",
-          cta: "Ver no GitHub",
+            "Detecção de falhas em rolamentos industriais a partir de sinais de vibração (IMS/NASA Run 2). Pipeline não supervisionado treinado só em dados saudáveis: Isolation Forest, OC-SVM, LOF e AutoEncoder, com limiar p99 por rolamento (FP ≈ 1%) e explicabilidade SHAP.",
+          tags: ["Python", "PyTorch", "SHAP", "Streamlit", "Predictive Maintenance"],
+          url: "https://industrialanm.streamlit.app/",
+          cta: "Ver demo ao vivo",
         },
         {
           label: "DESTAQUE",
@@ -479,12 +479,12 @@ export const MESSAGES: Record<Locale, Messages> = {
       secondary: [
         {
           label: "FEATURED",
-          title: "industrial-anomaly-detection",
+          title: "Predictive maintenance — bearing faults",
           description:
-            "Unsupervised anomaly detection on industrial time-series (IMS/NASA dataset): Isolation Forest, LOF, OC-SVM, AutoEncoder (PyTorch) and SHAP for explainability. Bootstrap confidence intervals and Streamlit dashboard for visualization.",
-          tags: ["Python", "PyTorch", "SHAP", "Streamlit", "Anomaly Detection"],
-          url: "https://github.com/RenanMiqueloti/industrial-anomaly-detection",
-          cta: "View on GitHub",
+            "Industrial bearing fault detection from vibration signals (IMS/NASA Run 2). Unsupervised pipeline trained on healthy data only: Isolation Forest, OC-SVM, LOF and AutoEncoder, with a per-bearing p99 threshold (FP ≈ 1%) and SHAP explainability.",
+          tags: ["Python", "PyTorch", "SHAP", "Streamlit", "Predictive Maintenance"],
+          url: "https://industrialanm.streamlit.app/",
+          cta: "View live demo",
         },
         {
           label: "FEATURED",


### PR DESCRIPTION
## Summary

- URL now points to the live Streamlit Cloud dashboard at https://industrialanm.streamlit.app/ instead of the GitHub repo
- CTA: "Ver demo ao vivo" / "View live demo"
- Title reframed from the repo slug to the domain ("Manutenção preditiva — falhas em rolamentos" / "Predictive maintenance — bearing faults")
- Description leads with the vibration / IMS NASA context, names the four detectors, and cites the verified per-bearing FP ≈ 1% calibration
- Tag swap: "Anomaly Detection" → "Predictive Maintenance"

PT-BR and EN copies updated in lockstep.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `next dev` reaches HTTP 200 on `/`
- [ ] Manual check: card renders in both locales and the CTA opens the Streamlit app