### PR TITLE
fix: add security response headers

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,19 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  async headers() {
+    const securityHeaders = [
+      { key: "X-Frame-Options", value: "DENY" },
+      { key: "X-Content-Type-Options", value: "nosniff" },
+      { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+      { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+      { key: "Content-Security-Policy", value: "frame-ancestors 'none'" },
+    ];
+    return [
+      // locale: false bypasses i18n path prefixing so /(.*) matches all routes
+      { source: "/(.*)", locale: false, headers: securityHeaders },
+    ];
+  },
   // i18n nativo do Next.js — gera /pt-BR (root) e /en/ como páginas estáticas
   // indexáveis separadamente pelo Google. Compatível com Vercel free tier (SSG).
   i18n: {


### PR DESCRIPTION
Adds 5 HTTP security headers via `next.config.js` to resolve findings from a Nikto scan.

**Headers adicionados:**
- `X-Frame-Options: DENY` — bloqueia clickjacking via iframe
- `Content-Security-Policy: frame-ancestors 'none'` — mesmo, via CSP moderno
- `X-Content-Type-Options: nosniff` — bloqueia MIME sniffing
- `Referrer-Policy: strict-origin-when-cross-origin` — limita vazamento de URL
- `Permissions-Policy: camera=(), microphone=(), geolocation=()` — restringe features do browser

**Por que `next.config.js` e não middleware?**
O pages router do Next.js não propaga response headers definidos em `NextResponse.next()` do middleware para a resposta final. A função `headers()` no config é a única forma suportada.

O `locale: false` na regra é necessário para que `/(.*)`  cubra `/` e `/pt-BR` sem ser reescrito para `/:locale/(.*)` pelo i18n.

Zero mudança visual ou funcional.