### PR TITLE
feat(analytics): PostHog + Clarity instrumentation for baseline phase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Analytics — todas opcionais; sem elas o site roda idêntico (no-op).
+# Setar em .env.local (dev) e no dashboard da Vercel (prod).
+
+# PostHog (eventos, funil, tempo de engajamento) — project API key em us.posthog.com
+NEXT_PUBLIC_POSTHOG_KEY=
+# Host do PostHog; default https://us.i.posthog.com (use https://eu.i.posthog.com se o projeto for EU)
+NEXT_PUBLIC_POSTHOG_HOST=
+
+# Microsoft Clarity (heatmaps + session recordings) — project id em clarity.microsoft.com
+NEXT_PUBLIC_CLARITY_ID=
+
+# Google Analytics 4 (opcional, integração pré-existente)
+NEXT_PUBLIC_GOOGLE_ANALYTICS=

--- a/components/Navigation/Header.nav.tsx
+++ b/components/Navigation/Header.nav.tsx
@@ -4,6 +4,7 @@
 import { useEffect, useState } from "react";
 import { useActiveSection } from "../../lib/useActiveSection";
 import { useLocale } from "../../lib/useLocale";
+import { track } from "../../lib/analytics";
 
 const Header = () => {
   const [scrolled, setScrolled] = useState(false);
@@ -69,6 +70,7 @@ const Header = () => {
               <a
                 key={l.id}
                 href={`#${l.id}`}
+                onClick={() => track("nav_click", { section: l.id })}
                 aria-current={isActive ? "true" : undefined}
                 className={`relative font-mono text-[11px] tracking-[0.18em] uppercase px-3 py-1 transition-colors ${isActive ? "text-emerald-300" : "text-zinc-500 hover:text-zinc-200"}`}
               >
@@ -100,7 +102,13 @@ const Header = () => {
         <div className="flex items-center gap-2 sm:gap-3 font-mono text-[11px] text-zinc-500 shrink-0">
           <button
             type="button"
-            onClick={toggle}
+            onClick={() => {
+              track("locale_toggle", {
+                from: locale,
+                to: locale === "pt" ? "en" : "pt",
+              });
+              toggle();
+            }}
             aria-label={`Switch language to ${t.header.localeToggleLabel}`}
             className="px-2 py-0.5 rounded border border-zinc-800 text-zinc-400 hover:text-emerald-300 hover:border-emerald-500/50 transition-colors text-[10px] tracking-[0.2em] uppercase"
           >

--- a/components/Sections/Contact.section.tsx
+++ b/components/Sections/Contact.section.tsx
@@ -2,6 +2,7 @@ import { AiOutlineGithub } from "react-icons/ai";
 import { FaLinkedinIn } from "react-icons/fa";
 import { Reveal } from "../Misc/Reveal.component";
 import { useT } from "../../lib/useLocale";
+import { track } from "../../lib/analytics";
 
 const SOCIALS = [
   {
@@ -58,6 +59,7 @@ const Contact = () => {
           <div className="mt-10 flex flex-wrap items-center justify-center gap-3">
             <a
               href={`mailto:${EMAIL}`}
+              onClick={() => track("contact_email_click")}
               className="group inline-flex items-center gap-3 px-7 py-3.5 bg-emerald-400 text-zinc-950 rounded-md font-mono font-semibold tracking-wide text-sm hover:bg-emerald-300 transition-all shadow-[0_0_18px_rgba(52,211,153,0.20)]"
             >
               <span>{c.ctaEmail}</span>
@@ -76,6 +78,7 @@ const Contact = () => {
                 href={s.href}
                 target="_blank"
                 rel="noopener noreferrer"
+                onClick={() => track("social_click", { network: s.label })}
                 className="group inline-flex items-center gap-2 px-4 py-2.5 text-zinc-400 border border-zinc-800 rounded-md font-mono text-sm hover:text-emerald-300 hover:border-emerald-500/50 transition-colors"
               >
                 <s.Icon size={16} />

--- a/components/Sections/Projects.section.tsx
+++ b/components/Sections/Projects.section.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Reveal } from "../Misc/Reveal.component";
 import { Window } from "../Misc/Window.component";
 import { useT } from "../../lib/useLocale";
+import { track } from "../../lib/analytics";
 
 const PER_PAGE = 2;
 
@@ -35,6 +36,12 @@ const Projects = () => {
                 href={featured.url}
                 target="_blank"
                 rel="noopener noreferrer"
+                onClick={() =>
+                  track("project_click", {
+                    title: featured.title,
+                    featured: true,
+                  })
+                }
                 className="group block h-full p-7 hover:bg-zinc-900/30 transition-colors"
               >
                 <span className="font-mono text-[11px] uppercase tracking-[0.2em] text-emerald-300/90">
@@ -82,6 +89,12 @@ const Projects = () => {
                       href={proj.url}
                       target="_blank"
                       rel="noopener noreferrer"
+                      onClick={() =>
+                        track("project_click", {
+                          title: proj.title,
+                          featured: false,
+                        })
+                      }
                       className={`group block p-5 transition-colors ${
                         isDisabled
                           ? "opacity-45 cursor-not-allowed pointer-events-none grayscale-[40%] bg-zinc-950/85"
@@ -146,6 +159,7 @@ const Projects = () => {
               href={p.seeAllUrl}
               target="_blank"
               rel="noopener noreferrer"
+              onClick={() => track("projects_see_all_click")}
               className="group inline-flex items-center gap-2 px-5 py-2.5 border border-zinc-800 text-zinc-400 rounded-md font-mono text-sm hover:border-emerald-500/50 hover:text-emerald-300 transition-colors"
             >
               <span>{p.seeAllCta}</span>

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,43 @@
+// lib/analytics.ts
+// Módulo único de analytics (PostHog). Env-gated como o GA em _app.tsx:
+// sem NEXT_PUBLIC_POSTHOG_KEY tudo vira no-op — dev/preview funcionam sem env.
+
+import posthog from "posthog-js";
+
+let initialized = false;
+
+export function initAnalytics(): void {
+  if (initialized || typeof window === "undefined") return;
+  const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  if (!key) return;
+
+  posthog.init(key, {
+    api_host:
+      process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com",
+    // Pageviews capturados manualmente (trackPageview) — o toggle PT/EN é uma
+    // navegação SPA que o pageview automático não cobre no pages router.
+    capture_pageview: false,
+    capture_pageleave: true,
+    autocapture: true,
+    respect_dnt: true,
+  });
+  initialized = true;
+}
+
+export function track(
+  event: string,
+  props?: Record<string, unknown>
+): void {
+  if (!initialized) return;
+  posthog.capture(event, props);
+}
+
+export function trackPageview(): void {
+  track("$pageview");
+}
+
+// Super property: todo evento subsequente carrega o idioma da sessão.
+export function setLocaleProperty(locale: string): void {
+  if (!initialized) return;
+  posthog.register({ locale });
+}

--- a/lib/useSectionViews.ts
+++ b/lib/useSectionViews.ts
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+import { track } from "./analytics";
+
+// Dispara `section_viewed` uma única vez por seção por pageload, quando a
+// seção cruza a faixa central do viewport — mesmo critério do scroll-spy
+// (useActiveSection), então "visto" = usuário realmente chegou na seção.
+export function useSectionViews(
+  ids: string[],
+  rootMargin = "-40% 0px -55% 0px"
+): void {
+  useEffect(() => {
+    if (typeof window === "undefined" || !("IntersectionObserver" in window)) {
+      return;
+    }
+
+    const seen = new Set<string>();
+    const observers: IntersectionObserver[] = [];
+
+    ids.forEach((id) => {
+      const el = document.getElementById(id);
+      if (!el) return;
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          if (entry?.isIntersecting && !seen.has(id)) {
+            seen.add(id);
+            track("section_viewed", { section: id });
+            observer.disconnect();
+          }
+        },
+        { rootMargin, threshold: 0 }
+      );
+      observer.observe(el);
+      observers.push(observer);
+    });
+
+    return () => observers.forEach((o) => o.disconnect());
+  }, [ids.join(","), rootMargin]);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "next": "^15.1.0",
         "next-seo": "^6.6.0",
+        "posthog-js": "^1.399.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-icons": "^5.5.0"
@@ -993,6 +994,21 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@posthog/core": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.40.0.tgz",
+      "integrity": "sha512-oGDbIwlTquNwdHbEL5ZLEkuW4UFkkEanfx3QAxDgyVbISv+OAA6YGQwrvo0JD3MUJEbJZvyh8XsX+WYDGw9XHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.393.0"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.393.0",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.393.0.tgz",
+      "integrity": "sha512-vzWeEJZ7ERQhFRoQYaP5jzN1JvIu46UJyHXsuv+dTGW2r3sMgREOhNxXLZjmFHwZ8/FOHQoyqqQmXTCXZSfMSg==",
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1064,6 +1080,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1077,6 +1094,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.1",
@@ -1123,6 +1147,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -1635,6 +1660,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2057,6 +2083,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2259,6 +2286,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2451,6 +2489,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -2688,6 +2735,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2861,6 +2909,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3149,6 +3198,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -4035,6 +4090,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4773,6 +4829,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4938,6 +4995,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/posthog-js": {
+      "version": "1.399.0",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.399.0.tgz",
+      "integrity": "sha512-8l+uZJZM3+OAc0D0+iLBMDRVfWF9s26Rt0jv8EC3kMJcA/9oyOets0zDgqIZk2TTfUs3H96ycLE6Lwj1wWG16Q==",
+      "license": "(Apache-2.0 AND MIT)",
+      "dependencies": {
+        "@posthog/core": "^1.40.0",
+        "@posthog/types": "^1.393.0",
+        "core-js": "^3.49.0",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.29.3",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.3.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.7",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
+      "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4970,6 +5061,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -4996,6 +5093,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5005,6 +5103,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5833,6 +5932,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5989,6 +6089,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6105,6 +6206,12 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/web-vitals": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "license": "Apache-2.0"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "next": "^15.1.0",
     "next-seo": "^6.6.0",
+    "posthog-js": "^1.399.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0"

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,13 +1,38 @@
 import type { AppProps } from "next/app";
 import "../styles/globals.css";
 
+import { useEffect } from "react";
 import Head from "next/head";
 import Script from "next/script";
+import { useRouter } from "next/router";
 import { LocaleProvider } from "../lib/useLocale";
+import {
+  initAnalytics,
+  setLocaleProperty,
+  trackPageview,
+} from "../lib/analytics";
 
 const GA_ID = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS;
+const CLARITY_ID = process.env.NEXT_PUBLIC_CLARITY_ID;
 
 function MyApp({ Component, pageProps }: AppProps) {
+  const router = useRouter();
+
+  useEffect(() => {
+    initAnalytics();
+  }, []);
+
+  useEffect(() => {
+    setLocaleProperty(router.locale ?? "pt-BR");
+  }, [router.locale]);
+
+  useEffect(() => {
+    trackPageview();
+    const onRouteChange = () => trackPageview();
+    router.events.on("routeChangeComplete", onRouteChange);
+    return () => router.events.off("routeChangeComplete", onRouteChange);
+  }, [router.events]);
+
   return (
     <LocaleProvider>
       {GA_ID && (
@@ -27,6 +52,17 @@ function MyApp({ Component, pageProps }: AppProps) {
             `}
           </Script>
         </>
+      )}
+      {CLARITY_ID && (
+        <Script id="ms-clarity" strategy="lazyOnload">
+          {`
+            (function(c,l,a,r,i,t,y){
+              c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+              t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+              y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+            })(window, document, "clarity", "script", "${CLARITY_ID}");
+          `}
+        </Script>
       )}
       <Head>
         <link rel="icon" href="/favicon.ico" />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -16,9 +16,13 @@ import {
   SITE_URL,
 } from "../lib/seo";
 import { useLocale } from "../lib/useLocale";
+import { useSectionViews } from "../lib/useSectionViews";
+
+const SECTION_IDS = ["about", "skills", "projects", "contact"];
 
 const Home: NextPage = () => {
   const { t, locale } = useLocale();
+  useSectionViews(SECTION_IDS);
   const m = t.meta;
   const canonical = locale === "en" ? `${SITE_URL}/en` : `${SITE_URL}/`;
   const ogImage = getOgImage(locale);


### PR DESCRIPTION
## O que muda

Instrumentação de analytics para a fase de baseline (2–4 semanas) que precede o teste A/B do site:

- **PostHog** (`lib/analytics.ts`): init env-gated em `NEXT_PUBLIC_POSTHOG_KEY`; pageviews manuais cobrindo a navegação SPA do toggle PT/EN; `capture_pageleave` para tempo de engajamento; locale como super property.
- **Eventos de conversão**: `contact_email_click`, `social_click` (LinkedIn/GitHub), `project_click` (featured/carrossel), `projects_see_all_click`, `nav_click`, `locale_toggle`.
- **Funil de scroll** (`lib/useSectionViews.ts`): `section_viewed` disparado uma vez por seção (about → skills → projects → contact), mesmo critério de viewport do scroll-spy existente.
- **Microsoft Clarity**: tag env-gated em `NEXT_PUBLIC_CLARITY_ID` (heatmaps + session recordings).
- `.env.example` documentando as variáveis.

Sem env vars setadas, tudo é no-op — o site permanece byte-idêntico em dev/preview sem configuração.

## Verificação

- `npm run typecheck` e `npm run build` passando (Next 15 / React 19).
- Evento de teste enviado com a project key real e confirmado ingerido via API do PostHog.
- Lockfile: diff semântico = +10 pacotes (posthog-js e deps), 0 removidos, 0 versões alteradas.

## Pós-merge

Setar na Vercel: `NEXT_PUBLIC_POSTHOG_KEY`, `NEXT_PUBLIC_POSTHOG_HOST`, `NEXT_PUBLIC_CLARITY_ID` (valores no `.env.local` local) e redeploy — sem isso produção não coleta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)