### PR TITLE
fix(i18n): make locale-redirect middleware actually run

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -9,17 +9,16 @@ export function middleware(request: NextRequest) {
 
   if (request.cookies.get("NEXT_LOCALE")) return NextResponse.next();
 
-  const { pathname } = request.nextUrl;
-  if (pathname === "/en" || pathname.startsWith("/en/")) {
-    return NextResponse.next();
-  }
+  // Com i18n nativo, nextUrl chega normalizado: /en vira locale "en" +
+  // pathname sem prefixo — por isso o locale é lido daqui, não do pathname.
+  if (request.nextUrl.locale === "en") return NextResponse.next();
 
   const acceptLanguage = request.headers.get("accept-language") ?? "";
   const primary = acceptLanguage.split(",")[0]?.trim().toLowerCase() ?? "";
 
   if (primary.startsWith("en")) {
     const url = request.nextUrl.clone();
-    url.pathname = pathname === "/" ? "/en" : `/en${pathname}`;
+    url.locale = "en";
     return NextResponse.redirect(url);
   }
 
@@ -27,5 +26,12 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/((?!_next/|api/|favicon.ico|robots.txt|sitemap.xml|.*\\.).*)"],
+  // locale: false — sem isso o Next expande o matcher com um segmento de
+  // locale obrigatório e a regex final nunca casa com "/" nem "/en".
+  matcher: [
+    {
+      source: "/((?!_next/|api/|favicon.ico|robots.txt|sitemap.xml|.*\\.).*)",
+      locale: false,
+    },
+  ],
 };


### PR DESCRIPTION
## Problema

O middleware de auto-detecção de idioma (`Accept-Language` → `/en`) **nunca executava** — nem em dev, nem em produção. Reproduzível: `curl -sI -H "Accept-Language: en-US" https://renanmiqueloti.vercel.app/` retorna 200 servindo pt-BR, sem redirect.

**Causa raiz:** com `i18n` nativo no `next.config.js`, o Next expande o matcher do middleware com um segmento de locale **obrigatório**. A regex compilada (visível em `.next/server/middleware-manifest.json`) era:

```
^(?:\/(_next\/data\/[^/]{1,}))?(?:\/((?!_next\/)[^/.]{1,}))(?:\/((?!...).*))(\.json)?[\/#\?]?$
```

Ela exige no mínimo **dois** segmentos de path — `/` e `/en` nunca casam, então o middleware não roda para nenhuma página real do site.

## Correção

- `locale: false` no matcher → o source casa contra o path bruto.
- Locale lido de `request.nextUrl.locale` (com i18n o `nextUrl` chega normalizado: `/en` vira `locale: "en"` + `pathname: "/"` — a checagem antiga `pathname === "/en"` também nunca seria verdadeira).
- Redirect via `url.locale = "en"` em vez de reescrever o pathname manualmente.

## Verificação (next build + next start local)

| Cenário | Resultado |
|---|---|
| `/` + `Accept-Language: en` | 307 → `/en` ✅ |
| `/` + `Accept-Language: pt-BR` | 200 ✅ |
| `/en` + `Accept-Language: en` | 200 (sem loop) ✅ |
| `/` + en + cookie `NEXT_LOCALE=pt-BR` | 200 ✅ |
| `/` + en + Googlebot UA | 200 (bots não redirecionam) ✅ |
| `/en/en` | 404 ✅ |
| `/sitemap.xml`, `/favicon.ico` | 200, fora do matcher ✅ |

`npm run lint` e `npm run typecheck` passam (warning pré-existente em `useSectionViews` não relacionado).

Obs.: em produção hoje `/en/en` responde 200 (conteúdo duplicado de `/en`) — vale re-testar após o deploy deste fix; localmente com o fix retorna 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)