### PR TITLE
fix(content): sync experience with LinkedIn source of truth

### DIFF
--- a/components/Misc/AgentTerminal.component.tsx
+++ b/components/Misc/AgentTerminal.component.tsx
@@ -50,12 +50,12 @@ const FOCUS_LINES: [string, string][] = [
 ];
 
 const EXPERIENCE_LINES: [string, string][] = [
-  ["CURRENT", "AI Ops Engineer — PJ — deploy e orquestração de agents em produção (2025–)."],
+  ["CURRENT", "AI Engineer @ Cruzeiro do Sul — via miqueloti.tech (PJ) — deploy e orquestração de agents em produção (2026–)."],
   ["PREVIOUS", "AI Engineer @ Tamy AI — agents HITL e RAG sobre bases internas (2025–2026)."],
   ["PREVIOUS", "Data Scientist @ WEG — IA/ML para indústria (2023–2025)."],
   [
     "FOUNDATION",
-    "TI / Análise de sistemas @ BirminD (2021–2023) · estágio web @ Melhor Escola (2019–2021).",
+    "TI / Análise de sistemas @ BirminD (2022–2023) · estágio web @ Melhor Escola (2018–2019).",
   ],
   ["DEGREE", "Computer & Information Sciences (2019–2023)."],
 ];
@@ -95,11 +95,11 @@ const TREE = `~/renan.agent/
 │   ├── agents-AI/
 │   └── mcp-tools-server/
 └── experience/
-    ├── 2025-pj-ai-ops/    (current)
+    ├── 2026-cruzeiro-do-sul/    (current)
     ├── 2025-tamy-ai/
     ├── 2023-weg/
-    ├── 2021-birmind/
-    └── 2019-melhor-escola/`;
+    ├── 2022-birmind/
+    └── 2018-melhor-escola/`;
 
 const PS_TABLE = `USER   PID   %CPU  %MEM  COMMAND
 renan  0001  4.2   ∞     /usr/bin/agent --model=claude
@@ -285,7 +285,7 @@ export const AgentTerminal = ({
                   ["OS", "AGENT.OS v0.4.2"],
                   ["Host", "renanmiqueloti.vercel.app"],
                   ["Shell", "zsh (renan.agent)"],
-                  ["Uptime", "∞ since 2019"],
+                  ["Uptime", "∞ since 2018"],
                   ["Role", PERSONA.role],
                   ["Focus", PERSONA.focus],
                   ["Mode", "hands-on · honesto sobre escopo"],
@@ -319,11 +319,11 @@ export const AgentTerminal = ({
               </div>
               <div className="space-y-3">
                 {([
-                  ["2025", "AI Ops Engineer — PJ", "atual · remoto", "deploy e orquestração de agents em produção"],
+                  ["2026", "AI Engineer @ Cruzeiro do Sul", "atual · via miqueloti.tech", "deploy e orquestração de agents em produção"],
                   ["2025", "AI Engineer @ Tamy AI", "2025–2026", "agentes de IA com LLMs · automação de decisões financeiras e operacionais"],
                   ["2023", "Data Scientist @ WEG", "2023–2025", "IA/ML aplicada a automação e otimização de processos industriais"],
-                  ["2021", "TI / Análise de sistemas @ BirminD", "2021–2023", "Git · Looker · Python · suporte e análise"],
-                  ["2019", "Estágio Web @ Melhor Escola", "2019–2021", "front-end e suporte"],
+                  ["2022", "TI / Análise de sistemas @ BirminD", "2022–2023", "Git · Looker · Python · suporte e análise"],
+                  ["2018", "Estágio Web @ Melhor Escola", "2018–2019", "front-end e suporte"],
                 ] as const).map(([year, title, meta, desc]) => (
                   <CvRow key={title} year={year} title={title} meta={meta} desc={desc} />
                 ))}

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -107,7 +107,7 @@ export const MESSAGES: Record<Locale, Messages> = {
       subtitleStrong: "AI Engineer",
       subtitleBody:
         " — sistemas com LLMs e ML aplicado.",
-      bridgeForNonTech: "5 anos em dados e tecnologia · 3 em IA aplicada · 2 em agents, RAG e AI Ops.",
+      bridgeForNonTech: "5 anos em dados e tecnologia · 3 em IA aplicada · 1 em agents, RAG e AI Ops.",
       ctaPrimary: "$ ver projetos",
       ctaSecondary: "vamos conversar",
       avatarFooter: "Brasil · remoto",
@@ -122,7 +122,7 @@ export const MESSAGES: Record<Locale, Messages> = {
         },
         {
           tag: "[  └─ now]",
-          text: "AI Ops Engineer — deploy e orquestração de agents em produção.",
+          text: "AI Engineer @ Cruzeiro do Sul — deploy e orquestração de agents em produção (2026–).",
         },
         {
           tag: "[  └─ prev]",
@@ -134,11 +134,11 @@ export const MESSAGES: Record<Locale, Messages> = {
         },
         {
           tag: "[FOUNDATION]",
-          text: "TI & análise de sistemas @ BirminD (2021–2023).",
+          text: "TI & análise de sistemas @ BirminD (2022–2023).",
         },
         {
           tag: "[INTERN]",
-          text: "Estágio web @ Melhor Escola (2019–2021).",
+          text: "Estágio web @ Melhor Escola (2018–2019).",
         },
         {
           tag: "[DEGREE]",
@@ -150,7 +150,7 @@ export const MESSAGES: Record<Locale, Messages> = {
         { key: "role", value: "ai engineer · mid/senior · pj" },
         { key: "focus", value: "aiops · agents · rag · mlops" },
         { key: "stack", value: "python · langgraph · aws · fastapi · mcp" },
-        { key: "since", value: "2021 (dados) · 2023 (ai/ml) · 2024 (agents)" },
+        { key: "since", value: "2018 (tech) · 2022 (dados) · 2023 (ai/ml) · 2025 (agents)" },
         { key: "location", value: "remoto · brasil · gmt-3" },
         { key: "langs", value: "pt-br (nativo) · en (B2)" },
       ],
@@ -324,7 +324,7 @@ export const MESSAGES: Record<Locale, Messages> = {
       subtitleStrong: "AI Engineer",
       subtitleBody:
         " — LLM systems and applied ML.",
-      bridgeForNonTech: "5 years in data & tech · 3 in applied AI · 2 in agents, RAG and AI Ops.",
+      bridgeForNonTech: "5 years in data & tech · 3 in applied AI · 1 in agents, RAG and AI Ops.",
       ctaPrimary: "$ see projects",
       ctaSecondary: "let's talk",
       avatarFooter: "Brazil · remote",
@@ -339,7 +339,7 @@ export const MESSAGES: Record<Locale, Messages> = {
         },
         {
           tag: "[  └─ now]",
-          text: "AI Ops Engineer — production agent deployment and orchestration.",
+          text: "AI Engineer @ Cruzeiro do Sul — production agent deployment and orchestration (2026–).",
         },
         {
           tag: "[  └─ prev]",
@@ -351,11 +351,11 @@ export const MESSAGES: Record<Locale, Messages> = {
         },
         {
           tag: "[FOUNDATION]",
-          text: "IT & systems analysis @ BirminD (2021–2023).",
+          text: "IT & systems analysis @ BirminD (2022–2023).",
         },
         {
           tag: "[INTERN]",
-          text: "Web internship @ Melhor Escola (2019–2021).",
+          text: "Web internship @ Melhor Escola (2018–2019).",
         },
         {
           tag: "[DEGREE]",
@@ -367,7 +367,7 @@ export const MESSAGES: Record<Locale, Messages> = {
         { key: "role", value: "ai engineer · mid/senior · contractor (pj)" },
         { key: "focus", value: "aiops · agents · rag · mlops" },
         { key: "stack", value: "python · langgraph · aws · fastapi · mcp" },
-        { key: "since", value: "2021 (data) · 2023 (ai/ml) · 2024 (agents)" },
+        { key: "since", value: "2018 (tech) · 2022 (data) · 2023 (ai/ml) · 2025 (agents)" },
         { key: "location", value: "remote · brazil · gmt-3" },
         { key: "langs", value: "en (B2) · pt-br (native)" },
       ],


### PR DESCRIPTION
## Summary
- Current role updated to **AI Engineer @ Cruzeiro do Sul** via miqueloti.tech (2026–), replacing the generic "AI Ops Engineer — PJ"
- Real dates from LinkedIn: BirminD **2022–2023** (was 2021–2023), Melhor Escola internship **2018–2019** (was 2019–2021)
- Derived claims adjusted: **1 year** in agents/RAG/AI Ops (was 2); `whoami` "since" line now traces 2018 (tech) · 2022 (data) · 2023 (ai/ml) · 2025 (agents)
- Interactive terminal kept coherent: `cv` timeline, `experience.log`, `tree`, `neofetch` uptime

Applies to both PT and EN locales. Verified rendering locally on `/` and `/en`; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)