### PR TITLE
feat(content): group WEG/BirminD like the PJ block and fix terminal boot

### DIFF
--- a/components/Misc/AgentTerminal.component.tsx
+++ b/components/Misc/AgentTerminal.component.tsx
@@ -52,11 +52,8 @@ const FOCUS_LINES: [string, string][] = [
 const EXPERIENCE_LINES: [string, string][] = [
   ["CURRENT", "AI Engineer @ Cruzeiro do Sul — via miqueloti.tech (PJ) — deploy e orquestração de agents em produção (2026–)."],
   ["PREVIOUS", "AI Engineer @ Tamy AI — agents HITL e RAG sobre bases internas (2025–2026)."],
-  ["PREVIOUS", "Data Scientist @ WEG — IA/ML para indústria (2023–2025)."],
-  [
-    "FOUNDATION",
-    "TI / Análise de sistemas @ BirminD (2022–2023) · estágio web @ Melhor Escola (2018–2019).",
-  ],
+  ["WEG", "tempo integral (2022–2025) — Data Scientist (2023–2025) · Analista de sistemas @ BirminD (2022–2023)."],
+  ["INTERN", "Estágio web @ Melhor Escola (2018–2019)."],
   ["DEGREE", "Computer & Information Sciences (2019–2023)."],
 ];
 
@@ -95,10 +92,12 @@ const TREE = `~/renan.agent/
 │   ├── agents-AI/
 │   └── mcp-tools-server/
 └── experience/
-    ├── 2026-cruzeiro-do-sul/    (current)
-    ├── 2025-tamy-ai/
-    ├── 2023-weg/
-    ├── 2022-birmind/
+    ├── miqueloti-tech/
+    │   ├── 2026-cruzeiro-do-sul/    (current)
+    │   └── 2025-tamy-ai/
+    ├── weg/
+    │   ├── 2023-data-scientist/
+    │   └── 2022-birmind/
     └── 2018-melhor-escola/`;
 
 const PS_TABLE = `USER   PID   %CPU  %MEM  COMMAND
@@ -192,12 +191,14 @@ export const AgentTerminal = ({
       { t: "sys", text: `[ready] agent online @ ${PERSONA.location}` },
       { t: "agent", text: "Olá. Sou o agent do Renan. Digite `help` ou tente `neofetch`." },
     ];
+    setLines([]);
     let i = 0;
     const tick = () => {
       if (cancelled) return;
       if (i >= seq.length) return;
-      setLines((l) => [...l, seq[i]]);
+      const ln = seq[i];
       i++;
+      setLines((l) => [...l, ln]);
       setTimeout(tick, 200 + Math.random() * 160);
     };
     tick();
@@ -322,7 +323,7 @@ export const AgentTerminal = ({
                   ["2026", "AI Engineer @ Cruzeiro do Sul", "atual · via miqueloti.tech", "deploy e orquestração de agents em produção"],
                   ["2025", "AI Engineer @ Tamy AI", "2025–2026", "agentes de IA com LLMs · automação de decisões financeiras e operacionais"],
                   ["2023", "Data Scientist @ WEG", "2023–2025", "IA/ML aplicada a automação e otimização de processos industriais"],
-                  ["2022", "TI / Análise de sistemas @ BirminD", "2022–2023", "Git · Looker · Python · suporte e análise"],
+                  ["2022", "Analista de sistemas @ BirminD (WEG)", "2022–2023", "Git · Looker · Python · suporte e análise"],
                   ["2018", "Estágio Web @ Melhor Escola", "2018–2019", "front-end e suporte"],
                 ] as const).map(([year, title, meta, desc]) => (
                   <CvRow key={title} year={year} title={title} meta={meta} desc={desc} />

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -130,11 +130,15 @@ export const MESSAGES: Record<Locale, Messages> = {
         },
         {
           tag: "[PREVIOUS]",
-          text: "Data Scientist @ WEG — ML para automação industrial (2023–2025).",
+          text: "WEG (2022–2025)",
         },
         {
-          tag: "[FOUNDATION]",
-          text: "TI & análise de sistemas @ BirminD (2022–2023).",
+          tag: "[  └─ ds]",
+          text: "Data Scientist — ML para automação industrial (2023–2025).",
+        },
+        {
+          tag: "[  └─ sys]",
+          text: "Analista de sistemas @ BirminD — Indústria 4.0 (2022–2023).",
         },
         {
           tag: "[INTERN]",
@@ -347,11 +351,15 @@ export const MESSAGES: Record<Locale, Messages> = {
         },
         {
           tag: "[PREVIOUS]",
-          text: "Data Scientist @ WEG — ML for industrial automation (2023–2025).",
+          text: "WEG (2022–2025)",
         },
         {
-          tag: "[FOUNDATION]",
-          text: "IT & systems analysis @ BirminD (2022–2023).",
+          tag: "[  └─ ds]",
+          text: "Data Scientist — ML for industrial automation (2023–2025).",
+        },
+        {
+          tag: "[  └─ sys]",
+          text: "Systems analyst @ BirminD — Industry 4.0 (2022–2023).",
         },
         {
           tag: "[INTERN]",


### PR DESCRIPTION
## Summary
- **experience.log**: WEG becomes an umbrella entry `[PREVIOUS] WEG (2022–2025)` with nested Data Scientist (2023–2025) and Systems analyst @ BirminD (2022–2023), mirroring the LinkedIn grouping — same visual pattern as the miqueloti.tech PJ block. Applied to PT and EN.
- **Terminal coherence**: `tree` groups `experience/miqueloti-tech/` and `experience/weg/`; `cv` timeline marks BirminD as `(WEG)`; `cat experience.log` uses "tempo integral (2022–2025)".
- **Terminal boot fix**: the boot effect's state updater read `seq[i]` after `i++`, skipping/duplicating lines (doubled `[ok] model: claude`), and effect re-runs (hot reload / StrictMode) stacked repeated boot sequences. Now each line is captured before `setState` and the effect resets lines on re-run.

Typecheck and lint clean; verified rendering locally on `/` and `/en`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)